### PR TITLE
Ci/publish gh pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-gh-pages:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Setup node environment (for building)
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.14.0
+
+      - name: Deploy to GitHub pages
+        run: |
+          yarn deploy
+        env:
+          CURRENT_BRANCH: main
+          GIT_USER: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}
+          GIT_PASS: ${{ secrets.OKP4_TOKEN }}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,6 +14,7 @@ const config = {
     favicon: "img/favicon.ico",
     organizationName: "okp4",
     projectName: "docs",
+    deploymentBranch: "gh-pages",
 
     presets: [
         [


### PR DESCRIPTION
Configure GitHub pages publication through the new `Publish` workflow:
- Currently triggered on every push to `main` as it is under active development
- Deploy using the `gh-pages` branch
- Deploy as @bot-anik 