### PR TITLE
ci(publish): don't use ssh for gh publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           yarn deploy
         env:
+          USE_SSH: false
           CURRENT_BRANCH: main
           GIT_USER: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}
           GIT_PASS: ${{ secrets.OKP4_TOKEN }}


### PR DESCRIPTION
Force github pages publication with @bot-anik through `https`.