### PR TITLE
Fix: revert baseURL from / to /docs/

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const config = {
     title: "ØKP4",
     tagline: "Open Knoledge Protocol For",
     url: "https://okp4.github.io",
-    baseUrl: "/",
+    baseUrl: "/docs/",
     onBrokenLinks: "warn",
     onBrokenMarkdownLinks: "warn",
     favicon: "img/favicon.ico",


### PR DESCRIPTION
Docusaurus does not load with `/` baseURL but only with `/docs/` on Github