### PR TITLE
Fix: Update redirect in index

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,5 +2,5 @@ import React from 'react';
 import {Redirect} from '@docusaurus/router';
 
 export default function Home() {
-  return <Redirect to="/docs" />;
+  return <Redirect to="/docs/docs" />;
 };


### PR DESCRIPTION
Considering Docusaurus [exemple](https://facebook.github.io/metro) in the documentation, there is a [landing page](https://github.com/facebook/metro/blob/main/website/src/pages/index.js) for metro doc.
The base URL is `/metro` (based on the project name) and Docusaurus places the documentation on `/metro/docs`.
The problem for us is that the project is named `docs` so the baseURL will be `/docs` and Docusauraus will use `/docs/docs` as a path for the documentation.
If we change the redirect in `src/page/index.js` from `/docs` to `/docs/docs`, it should redirect to the documentation instead of the blank landing page.