### PR TITLE
Chore: Update baseURL after DNS update

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const config = {
     title: "ØKP4",
     tagline: "Open Knoledge Protocol For",
     url: "https://okp4.github.io",
-    baseUrl: "/docs/",
+    baseUrl: "/",
     onBrokenLinks: "warn",
     onBrokenMarkdownLinks: "warn",
     favicon: "img/favicon.ico",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,5 +2,5 @@ import React from 'react';
 import {Redirect} from '@docusaurus/router';
 
 export default function Home() {
-  return <Redirect to="/docs/docs/whitepaper/abstract" />;
+  return <Redirect to="/docs/whitepaper/abstract" />;
 };


### PR DESCRIPTION
With the help of @amimart & @ccamel, our DNS has been configured to redirect the domain `docs.okp4.network` to `okp4.github.io`.

Consequently, the following changes should be considered:
- update Docusaurus baseURL from `/docs` to `/`
- update redirection in `index.js` from `/docs/docs/whitepaper/abstract` to `/docs/whitepaper/abstract`