### PR TITLE
ci(pages): specify custom url targeted CNAME

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,3 +33,4 @@ jobs:
         with:
           github_token: ${{ secrets.OKP4_TOKEN }}
           publish_dir: ./build
+          cname: docs.okp4.network


### PR DESCRIPTION
We set up the CNAME redirect to the repository's github pages through `docs.okp4.network`, we need to specify it when publishing.