### PR TITLE
CI: Auto fix markdown

### DIFF
--- a/.github/workflows/auto-fix-md.yml
+++ b/.github/workflows/auto-fix-md.yml
@@ -1,0 +1,28 @@
+name: Auto fix Markdown
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  auto-fix-markdown:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Lint markdown files
+        uses: avto-dev/markdown-lint@v1.5.0
+        with:
+          args: "**/*.md"
+          fix: true
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }}
+          commit_user_email: ${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}
+          commit_author: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }} <${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}>
+          commit_message: "chore: autofix markdown files"


### PR DESCRIPTION
Add a Github Action triggering everyday at midnight or manually to automatically fix markdown files.
Changes are commit using [Bot Anik](https://github.com/bot-anik).