### PR TITLE
Fix/article main style

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -35,6 +35,7 @@
     0% 0% no-repeat padding-box;
   --ifm-navbar-background-color: white;
   --ifm-background-image-url: url("/static/img/universe-light.png");
+  --ifm-article-anchor-color: #877b65;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -29,11 +29,18 @@ html {
     background-image: var(--ifm-background-image-url);
     background-repeat: no-repeat;
 
-    article > *:not(footer) {
-      a,
-      a:hover {
-        color: var(--ifm-article-anchor-color);
-        font-weight: bold;
+    article {
+      > *:not(footer) {
+        a,
+        a:hover {
+          color: var(--ifm-article-anchor-color);
+          font-weight: bold;
+        }
+      }
+
+      table {
+        display: table;
+        margin: var(--ifm-spacing-vertical) auto;
       }
     }
   }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -28,6 +28,14 @@ html {
   main {
     background-image: var(--ifm-background-image-url);
     background-repeat: no-repeat;
+
+    article > *:not(footer) {
+      a,
+      a:hover {
+        color: var(--ifm-article-anchor-color);
+        font-weight: bold;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This PR comes to:

-  add some color for all anchors (links) declared in main articles. This color comes from OKP4 Design System, info semantic color (https://okp4.github.io/ui/?path=/docs/atoms-brand-identity-colors--page)
- center all `tables` 

**Dark theme**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/47554752/173360506-17980ac8-4c32-4304-8273-989482e13e15.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/47554752/173366538-3a325145-8b4c-4042-a0c0-0c34f05aecd1.png">

**Light theme**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/47554752/173360563-7f30686a-a983-4522-9833-771369afae12.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/47554752/173366607-b066e989-1bec-463f-8c7c-3660abc4664f.png">
