### PR TITLE
fix: reword 'stack' to 'stake'

### DIFF
--- a/docs/whitepaper/token-model.md
+++ b/docs/whitepaper/token-model.md
@@ -122,7 +122,7 @@ Being a Curator in our ecosystem comes with certain risks. Let’s have a look a
 2. Bonding curve risk: Asset depreciation as a result of depositing into the bonding curve of an item whose curation shares are being burned by other Curators.
 3. Non-functional risk: An item can fail due to a bug. A failed item does not accrue royalties. As a result, you will have to wait until the developer fixes the bug and deploys a new version.
 4. Item assessment risk: Marking false judgments about the attractiveness of an item.
-5. Gas price risk: High gas prices could reduce your profit margin, especially if you are curating with a smaller stack of KNOW.
+5. Gas price risk: High gas prices could reduce your profit margin, especially if you are curating with a smaller stake of KNOW.
 6. Curation taxes risk: 2% curation fee. This can become costly if Curators often switch to another subgraph or have to commit to the latest version of the subgraph. It is not a "risk", but it is something to keep in mind.
 
 ## Governance

--- a/docs/whitepaper/tokenomics.md
+++ b/docs/whitepaper/tokenomics.md
@@ -29,7 +29,7 @@ The cliff and vesting terms are the following:
 
 **Maximum supply: 350,000,000 $KNOW** (including block rewards, reached after 80 years)
 
-The additional 150M tokens are released as block rewards (also called stacking rewards) for validators and delegators over the 80 years following the launch.
+The additional 150M tokens are released as block rewards (also called staking rewards) for validators and delegators over the 80 years following the launch.
 
 Here are the details regarding the different allocations:
 
@@ -75,7 +75,7 @@ This strategic reserve will be controlled by a multisig comprised of foundation 
 
 ![Supply Schedule](/img/content/Supply-schedule.png)
 
-### Stacking rewards
+### Staking rewards
 
 Validators and delegators are crucial to ensuring security of the OKP4 blockchain and help with block proposing, verification and validation.
 
@@ -92,7 +92,7 @@ Block reward for validators and delegators will depend on the inflation number t
 - Year 5: 6.144%
 - Year X: X-1 * 0.8
 
-Stacking APR will obviously be higher than the numbers quoted above, depending on the circulating supply and percentage of the circulating supply stacked.
+Staking APR will obviously be higher than the numbers quoted above, depending on the circulating supply and percentage of the circulating supply staked.
 
 ## Overview after 3 years
 


### PR DESCRIPTION
Correct some misspelling of _stake_, _staking_ and _stacking_ being different notions.

I replaced it everywhere it seems relevant to me, however, I may had a heavy-hand so I'll let you judge ⚖️.