### PR TITLE
chore: add matomo usage tracking

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -146,6 +146,9 @@ const config = {
         hashed: true
       }
     ]
+  ],
+  scripts: [
+    "/js/matomo.js",
   ]
 }
 

--- a/static/js/matomo.js
+++ b/static/js/matomo.js
@@ -1,0 +1,15 @@
+var _paq = window._paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u = "https://okp4.matomo.cloud/";
+  _paq.push(['setTrackerUrl', u + 'matomo.php']);
+  _paq.push(['setSiteId', '3']);
+  var d = document,
+      g = d.createElement('script'),
+      s = d.getElementsByTagName('script')[0];
+  g.async = true;
+  g.src = '//cdn.matomo.cloud/okp4.matomo.cloud/matomo.js';
+  s.parentNode.insertBefore(g, s);
+})();


### PR DESCRIPTION
Add web analytics to the [Docusaurus website](https://docs.okp4.network/) web site using [matomo](https://matomo.org/).