### PR TITLE
ci(workflow): add workflow to bump okp4d version

### DIFF
--- a/.github/workflows/bump-okp4d-version.yml
+++ b/.github/workflows/bump-okp4d-version.yml
@@ -1,0 +1,33 @@
+name: Bump okp4d version
+on:
+  workflow_dispatch:
+    inputs:
+      okp4dVersion:
+        description: "Version of okp4d"
+        required: true
+
+jobs:
+  bumpd-okp4-version:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.OKP4_TOKEN }}
+
+      - name: Bump okp4d version
+        run: |
+          dataFile="docs/nodes/data.json"
+          tmpFile=$(mktemp)
+
+          jq '.okp4dVersion |= "${{ github.event.inputs.okp4dVersion }}"' "$dataFile" > "$tmpFile" &&
+          cp "$tmpFile" "$dataFile" &&
+          rm -f "$tmpFile"
+
+      - name: Commit okp4d version change
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_user_name: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }}
+          commit_user_email: ${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}
+          commit_author: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }} <${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}>
+          commit_message: "build: bump okp4d version to ${{ github.event.inputs.okp4dVersion }}"


### PR DESCRIPTION
## Purpose

This PR brings a first step of automation of the `okp4d` version update (referenced in the `docs/nodes/data.json` file) to keep documentation in sync, and implemented as a parameterized workflow invocable by another workflow (typically [okp4/okp4d](github.com/okp4/okp4d)) (or possibly manually if necessary).

## Note

To come, the invocation of this workflow after release on the [okp4/okp4d](github.com/okp4/okp4d) project.