### PR TITLE
Fix build failure on index cards

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,8 +34,6 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
         </p>
       </div>
     </div>
-  </div>
-</div>
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
         <a
@@ -152,8 +150,6 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
         <p class="card-text">Get to know more about OKP4.</p>
       </div>
     </div>
-  </div>
-</div>
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
         <a href="https://linktr.ee/okp4" class="card-title card-link stretched-link">
@@ -162,8 +158,6 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
         <p class="card-text">Follow our different social networks.</p>
       </div>
     </div>
-  </div>
-</div>
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
         <a href="https://github.com/okp4/" class="card-title card-link stretched-link">
@@ -184,8 +178,6 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
         <p class="card-text">Know more about our vision.</p>
       </div>
     </div>
-  </div>
-</div>
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
         <a href="https://okp4.network" class="card-title card-link stretched-link">

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,6 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
   </div>
 </div>
 
-
 ## Learn OKP4 concepts
 
 <div class="docs-card-container">
@@ -188,7 +187,6 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
     </div>
   </div>
 </div>
-
 
 Welcome to the OKP4 community! Find out more about us at:
 


### PR DESCRIPTION
Since the last [commit](https://github.com/okp4/docs/commit/91ab60e7243e43f625bf2d2775aba93138f67714) on main branch, the build failed, caused by a too many close html balise. 

@MdechampG Could you please check if this fix does not change the expected appearance on home page cards ☺️. 

<img width="1552" alt="Capture d’écran 2022-10-27 à 18 16 06" src="https://user-images.githubusercontent.com/33665639/198345136-36d3fc63-18ba-44f7-98ba-f2b73beaf337.png">
<img width="1552" alt="Capture d’écran 2022-10-27 à 18 16 01" src="https://user-images.githubusercontent.com/33665639/198345157-0886f704-cef7-477b-8c40-cb4b3cc81be7.png">
<img width="1552" alt="Capture d’écran 2022-10-27 à 18 15 54" src="https://user-images.githubusercontent.com/33665639/198345172-97d31270-3a86-4c1e-b6d4-8c2c21c16994.png">


This PR is needed for #136... 