### PR TITLE
🐛 Fix redirect for `/docs` path

### DIFF
--- a/static/js/redirect.js
+++ b/static/js/redirect.js
@@ -1,3 +1,3 @@
-if (window.location.pathname.startsWith("/docs/")) {
-    window.location.pathname = window.location.pathname.replace("/docs/", "/");
+if (window.location.pathname.startsWith("/docs")) {
+    window.location.pathname = window.location.pathname.replace("/docs", "");
 }


### PR DESCRIPTION
Redirect not work if the `/docs` doesn't end by `/`.

@MdechampG FYI