### PR TITLE
⬆️ Update github action runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/auto-fix-md.yml
+++ b/.github/workflows/auto-fix-md.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   auto-fix-markdown:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   auto-merge-dependabot:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Auto merge PR

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build-yarn:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/follow-contributor.yml
+++ b/.github/workflows/follow-contributor.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   follow-user:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Follow user
         uses: okp4/follow-contributor-action@v1.1.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   lint-commits:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.actor != 'dependabot[bot]'
     steps:
       - name: Check out repository
@@ -27,7 +27,7 @@ jobs:
         uses: wagoid/commitlint-github-action@v5
 
   lint-markdown:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -39,7 +39,7 @@ jobs:
           ignore: contracts/**/*.md contracts_versioned_docs/**/*.md modules/**/*.md modules_versioned_docs/**/*.md
 
   lint-yaml:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
         uses: ibiqlik/action-yamllint@v3.1.1
 
   lint-json:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -71,7 +71,7 @@ jobs:
           ' sh {} +
 
   report-new-dependencies:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
       - name: Check out repository
@@ -83,7 +83,7 @@ jobs:
           token: ${{ secrets.OKP4_TOKEN }}
 
   lint-branch-name:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: github.actor != 'dependabot[bot]' && github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')
     steps:
       - name: Check branch name conventions
@@ -118,7 +118,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
 
   lint-scss:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   publish-gh-pages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Bumps github runners to [ubuntu-22.04](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources).
