### PR TITLE
ci(dependabot): update reviewers and assignees

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,26 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: weekly
     reviewers:
-      - "maintainers"
+      - amimart
+      - ccamel
+      - fredericvilcot
+    assignees:
+      - amimart
+      - ccamel
+      - fredericvilcot
+    open-pull-requests-limit: 5
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: "daily"
+      interval: weekly
     reviewers:
-      - "maintainers"
+      - ccamel
+      - fredericvilcot
+    assignees:
+      - ccamel
+      - fredericvilcot
+    open-pull-requests-limit: 5


### PR DESCRIPTION
`dependabot` cannot add `maintainers` as reviewers, so this PR:

- adds named reviewers and assignees
- enhances the whole workflow