### PR TITLE
🐛 Fix: remove docs folder from update docs workflow

### DIFF
--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Copy updated docs
         run: |
-          rm -rf ${{ github.event.inputs.section }}/docs/*
-          cp -R tmp/${{ github.event.inputs.docs_directory }}.md ${{ github.event.inputs.section }}/docs
+          rm -rf ${{ github.event.inputs.section }}/*
+          cp -R tmp/${{ github.event.inputs.docs_directory }}.md ${{ github.event.inputs.section }}
           rm -rf tmp/*
 
       - name: Setup node environment


### PR DESCRIPTION
Since https://github.com/okp4/docs/pull/139 PR, the workflow triggered to update docs on modules and contracts documentations is no longer working. The `docs` path has been removed and script was not updated accordingly. 