### PR TITLE
✏️ Draft module documentation

### DIFF
--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
+        if: ${{ github.event.inputs.draft == false }}
         with:
           commit-message: "docs(${{ github.event.inputs.section }}): add ${{ github.event.inputs.section }} ${{ github.event.inputs.version }} version"
           committer: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }} <${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}>

--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "New docs version (repository tag)"
+        description: "New docs version (repository tag or repository ref)"
         required: true
       repository:
         description: "Set the repository that docs has been updated (okp4/contracts | okp4/okp4d)"
@@ -15,6 +15,10 @@ on:
         description: "On which directory documentation is located (docs/* | docs/proto/* | docs/command/*)"
         required: false
         default: "docs/*"
+      draft:
+        description: "Indicate if the publication of the documentation should be kept in draft and no new version should be released"
+        required: false
+        default: false
 
 jobs:
   update-versioned-doc:
@@ -54,9 +58,19 @@ jobs:
           node-version: 16.18
 
       - name: Bump new version
+        if: ${{ github.event.inputs.draft == false }}
         run: |
           yarn
           yarn run docusaurus docs:version:${{ github.event.inputs.section }} ${{ github.event.inputs.version }}
+
+      - name: Commit documentation draft
+        uses: stefanzweifel/git-auto-commit-action@v4
+        if: ${{ github.event.inputs.draft }}
+        with:
+          commit_user_name: ${{ secrets.OKP4_BOT_GIT_COMMITTER_NAME }}
+          commit_user_email: ${{ secrets.OKP4_BOT_GIT_COMMITTER_EMAIL }}
+          commit_author: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }} <${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}>
+          commit_message: "docs: update draft docs for ${{ github.event.inputs.section }}"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4

--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -16,6 +16,7 @@ on:
         required: false
         default: "docs/*"
       draft:
+        type: boolean
         description: "Indicate if the publication of the documentation should be kept in draft and no new version should be released"
         required: false
         default: false


### PR DESCRIPTION
Add new optional parameter to allow publish documentation in draft mode directly on main branch. Draft documentation is located in the `./<section>` folder, all files in this folder is indicated on docusaurus as the next release documentation.

A new PR (in progress) on okp4d project will notify each time a documentation has been updated on main branch and will be published in draft on this repository. 

This PR can be merged even if no PR has been created in okp4d repository or contract repository. It could be manually triggered on the [action section of GitHub.](https://github.com/okp4/docs/actions/workflows/update-versioned-docs.yml)

<img width="1001" alt="Capture d’écran 2023-01-11 à 10 44 21" src="https://user-images.githubusercontent.com/33665639/211772537-f51c3d13-a7c2-4567-b5dd-c7bd945c1d2c.png">
