### PR TITLE
🐛 Ci : remove concurrency on trigger update docs

### DIFF
--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -1,4 +1,7 @@
 name: Update versioned docs
+
+concurrency: update-docs-${{ github.ref }}
+
 on:
   workflow_dispatch:
     inputs:

--- a/docs/nodes/kms.md
+++ b/docs/nodes/kms.md
@@ -40,7 +40,7 @@ You will need the following prerequisites:
 
   - ✅ macOS (Homebrew)
   
-    ```
+    ```bash
     #!/bin/bash
     brew install libusb
     ```


### PR DESCRIPTION
When trigger update docs from `okp4d` repository, two job is launched at the same time (`modules` documentation and `commands` documentation), when the first job push on repository, the second one failed since the ref has changed. To fix this I have added the concurrency option named `update-docs-${{ github.ref }}` that will make a queue and execute job once at a time. 