### PR TITLE
🐛 Fix remove entirely the temp folder for changed-files detection

### DIFF
--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           rm -rf ${{ github.event.inputs.section }}/*
           cp -R tmp/${{ github.event.inputs.docs_directory }}.md ${{ github.event.inputs.section }}
-          rm -rf tmp/*
+          rm -rf tmp
 
       - name: Setup node environment
         uses: actions/setup-node@v3


### PR DESCRIPTION
For trigger the docs update, changes-files not working since a temporary folder has been created but not removed entirely (only files inside). So remove this folder also. I hope is the last PR about the docs triggering 🤞