### PR TITLE
🐛 Fix(ci): ignore unmatch file 

### DIFF
--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           rm -rf ${{ github.event.inputs.section }}/*
           cp -R tmp/${{ github.event.inputs.docs_directory }}.md ${{ github.event.inputs.section }}
-          git rm --cached tmp
+          git rm --ignore-unmatch --cached tmp
           rm -rf .git/modules/tmp
           rm -rf tmp
 


### PR DESCRIPTION
Another PR (again) to fix workflow docs update, this time it's for contracts repository that failed on the last (and first for this module) triggering. Ignore git rm if files doesn't exist.