### PR TITLE
feat: add prolog codeblock support

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -193,7 +193,8 @@ const config = {
       },
       prism: {
         theme: lightCodeTheme,
-        darkTheme: darkCodeTheme
+        darkTheme: darkCodeTheme,
+        additionalLanguages: ['prolog'],
       },
       colorMode: {
         defaultMode: 'dark'


### PR DESCRIPTION
Add support for the prolog code on code block : 

<img width="1080" alt="Capture d’écran 2023-06-15 à 16 50 24" src="https://github.com/okp4/docs/assets/33665639/56f90d1f-494a-49df-a6da-997625d0b0d7">
