### PR TITLE
Add Kroki! support

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -3,248 +3,261 @@
 const lightCodeTheme = require('prism-react-renderer/themes/github')
 const darkCodeTheme = require('prism-react-renderer/themes/dracula')
 
-/** @type {import('@docusaurus/types').Config} */
-const config = {
-  title: 'OKP4 Docs',
-  tagline: 'Unleash the Knowledge Economy 🚀',
-  url: 'https://okp4.github.io',
-  baseUrl: '/',
-  onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
-  favicon: 'img/favicon.ico',
-  organizationName: 'OKP4',
-  projectName: 'docs',
-  deploymentBranch: 'gh-pages',
-  trailingSlash: false,
+async function createconfig() {
+  const { remarkKroki } = await import('remark-kroki')
 
-  presets: [
-    [
-      'classic',
-      /** @type {import('@docusaurus/preset-classic').Options} */
-      ({
-        docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: ({ docPath }) => `https://github.com/okp4/docs/edit/main/docs/${docPath}`,
-          remarkPlugins: [require('remark-math'), require('mdx-mermaid')],
-          rehypePlugins: [require('rehype-katex')],
-          routeBasePath: "/",
-        },
-        blog: false,
-        theme: {
-          customCss: require.resolve('./src/scss/custom.scss')
-        }
-      })
-    ]
-  ],
-  stylesheets: [
-    {
-      href: 'https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css',
-      type: 'text/css',
-      integrity:
-        'sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM',
-      crossorigin: 'anonymous',
-    },
-  ],
-  themeConfig:
-    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
-    ({
-      navbar: {
-        title: 'OKP4',
-        logo: {
-          alt: 'OKP4 Logo',
-          src: '/img/logotype-okp4-light.svg',
-          srcDark: '/img/logotype-okp4-dark.svg'
-        },
-        items: [
-          {
-            to: '/whitepaper/abstract',
-            position: 'left',
-            label: 'Whitepaper',
-            activeBasePath: "/whitepaper"
-          },
-          {
-            to: '/nodes/introduction',
-            position: 'left',
-            label: 'Nodes & Validators',
-            activeBasePath: "/nodes"
-          },
-          {
-            to: '/technical-documentation/introduction',
-            position: 'left',
-            label: 'Technical documentation',
-            activeBasePath: "/technical-documentation"
-          },
-          {
-            to: '/tutorials/overview',
-            position: 'left',
-            label: 'Tutorials',
-            activeBasePath: "/tutorials"
-          },
-          {
-            type: 'dropdown',
-            label: 'API',
-            position: 'left',
-            items: [
-              {
-                type: 'doc',
-                label: 'Contracts',
-                docId: 'README',
-                docsPluginId: 'contracts'
-              },
-              {
-                type: 'doc',
-                label: 'Modules',
-                docId: 'logic',
-                docsPluginId: 'modules',
-              },
-              {
-                type: 'doc',
-                label: 'Commands',
-                docId: 'okp4d',
-                docsPluginId: 'commands',
-              },
+  /** @type {import('@docusaurus/types').Config} */
+  const config = {
+    title: 'OKP4 Docs',
+    tagline: 'Unleash the Knowledge Economy 🚀',
+    url: 'https://okp4.github.io',
+    baseUrl: '/',
+    onBrokenLinks: 'throw',
+    onBrokenMarkdownLinks: 'throw',
+    favicon: 'img/favicon.ico',
+    organizationName: 'OKP4',
+    projectName: 'docs',
+    deploymentBranch: 'gh-pages',
+    trailingSlash: false,
+
+    presets: [
+      [
+        'classic',
+        /** @type {import('@docusaurus/preset-classic').Options} */
+        ({
+          docs: {
+            sidebarPath: require.resolve('./sidebars.js'),
+            editUrl: ({ docPath }) => `https://github.com/okp4/docs/edit/main/docs/${docPath}`,
+            remarkPlugins: [
+              require('remark-math'),
+              require('mdx-mermaid'),
+              [
+                remarkKroki,
+                {
+                  server: 'https://kroki.io/',
+                  output: 'inline-svg',
+                  alias: ['plantuml', 'structurizr', 'bpmn', 'graphviz']
+                }
+              ]
             ],
+            rehypePlugins: [require('rehype-katex')],
+            routeBasePath: '/'
           },
-          {
-            to: '/faq',
-            position: 'left',
-            label: 'FAQ',
-            activeBasePath: "/faq"
-          },
-          {
-            type: 'docsVersionDropdown',
-            position: 'right',
-            dropdownItemsAfter: [{to: '/contracts/', label: 'Latest version'}],
-            docsPluginId: 'contracts',
-            dropdownActiveClassDisabled: true,
-          },
-          {
-            type: 'docsVersionDropdown',
-            position: 'right',
-            dropdownItemsAfter: [{to: '/modules/logic', label: 'Latest version'}],
-            docsPluginId: 'modules',
-            dropdownActiveClassDisabled: true,
-          },
-          {
-            type: 'docsVersionDropdown',
-            position: 'right',
-            dropdownItemsAfter: [{to: '/commands/okp4d', label: 'Latest version'}],
-            docsPluginId: 'commands',
-            dropdownActiveClassDisabled: true,
-          },
-          {
-          href: 'https://discord.gg/okp4',
-          position: 'right',
-          className: 'header-discord-link',
-          'aria-label': 'Discord'
-          },
-          {
-          href: 'https://github.com/okp4',
-          position: 'right',
-          className: 'header-github-link',
-          'aria-label': 'GitHub repository'
+          blog: false,
+          theme: {
+            customCss: require.resolve('./src/scss/custom.scss')
           }
-        ]
-      },
-      footer: {
-        style: 'dark',
-        links: [
-          {
-            title: 'Docs',
-            items: [
-              {
-                label: 'Whitepaper',
-                to: '/whitepaper/abstract'
-              }
-            ]
-          },
-          {
-            title: 'Community',
-            items: [
-              {
-                label: 'Discord',
-                href: 'https://discord.gg/okp4'
-              },
-              {
-                label: 'Twitter',
-                href: 'https://twitter.com/OKP4_Protocol'
-              },
-              {
-                label: 'GitHub',
-                href: 'https://github.com/okp4'
-              }
-            ]
-          },
-          {
-            title: 'More',
-            items: [
-              {
-                label: 'Medium',
-                href: 'https://medium.com/okp4'
-              },
-              {
-                label: 'OKP4.network',
-                href: 'https://okp4.network'
-              }
-            ]
-          }
-        ],
-        copyright: `Copyright © ${new Date().getFullYear()} OKP4`
-      },
-      prism: {
-        theme: lightCodeTheme,
-        darkTheme: darkCodeTheme,
-        additionalLanguages: ['prolog'],
-      },
-      colorMode: {
-        defaultMode: 'dark'
-      },
-      docs: {
-        sidebar: {
-          hideable: true,
-          autoCollapseCategories: true
-        },
-      },
-    }),
-  plugins: [
-    'docusaurus-plugin-sass',
-    ['drawio', {}],
-    [
-      '@easyops-cn/docusaurus-search-local',
+        })
+      ]
+    ],
+    stylesheets: [
       {
-        hashed: true,
-        docsRouteBasePath: "/"
+        href: 'https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css',
+        type: 'text/css',
+        integrity: 'sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM',
+        crossorigin: 'anonymous'
       }
     ],
-    [
-      '@docusaurus/plugin-content-docs',
-      {
-        id: 'contracts',
-        path: 'contracts',
-        routeBasePath: 'contracts/'
-      },
+    themeConfig:
+      /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+      ({
+        navbar: {
+          title: 'OKP4',
+          logo: {
+            alt: 'OKP4 Logo',
+            src: '/img/logotype-okp4-light.svg',
+            srcDark: '/img/logotype-okp4-dark.svg'
+          },
+          items: [
+            {
+              to: '/whitepaper/abstract',
+              position: 'left',
+              label: 'Whitepaper',
+              activeBasePath: '/whitepaper'
+            },
+            {
+              to: '/nodes/introduction',
+              position: 'left',
+              label: 'Nodes & Validators',
+              activeBasePath: '/nodes'
+            },
+            {
+              to: '/technical-documentation/introduction',
+              position: 'left',
+              label: 'Technical documentation',
+              activeBasePath: '/technical-documentation'
+            },
+            {
+              to: '/tutorials/overview',
+              position: 'left',
+              label: 'Tutorials',
+              activeBasePath: '/tutorials'
+            },
+            {
+              type: 'dropdown',
+              label: 'API',
+              position: 'left',
+              items: [
+                {
+                  type: 'doc',
+                  label: 'Contracts',
+                  docId: 'README',
+                  docsPluginId: 'contracts'
+                },
+                {
+                  type: 'doc',
+                  label: 'Modules',
+                  docId: 'logic',
+                  docsPluginId: 'modules'
+                },
+                {
+                  type: 'doc',
+                  label: 'Commands',
+                  docId: 'okp4d',
+                  docsPluginId: 'commands'
+                }
+              ]
+            },
+            {
+              to: '/faq',
+              position: 'left',
+              label: 'FAQ',
+              activeBasePath: '/faq'
+            },
+            {
+              type: 'docsVersionDropdown',
+              position: 'right',
+              dropdownItemsAfter: [{ to: '/contracts/', label: 'Latest version' }],
+              docsPluginId: 'contracts',
+              dropdownActiveClassDisabled: true
+            },
+            {
+              type: 'docsVersionDropdown',
+              position: 'right',
+              dropdownItemsAfter: [{ to: '/modules/logic', label: 'Latest version' }],
+              docsPluginId: 'modules',
+              dropdownActiveClassDisabled: true
+            },
+            {
+              type: 'docsVersionDropdown',
+              position: 'right',
+              dropdownItemsAfter: [{ to: '/commands/okp4d', label: 'Latest version' }],
+              docsPluginId: 'commands',
+              dropdownActiveClassDisabled: true
+            },
+            {
+              href: 'https://discord.gg/okp4',
+              position: 'right',
+              className: 'header-discord-link',
+              'aria-label': 'Discord'
+            },
+            {
+              href: 'https://github.com/okp4',
+              position: 'right',
+              className: 'header-github-link',
+              'aria-label': 'GitHub repository'
+            }
+          ]
+        },
+        footer: {
+          style: 'dark',
+          links: [
+            {
+              title: 'Docs',
+              items: [
+                {
+                  label: 'Whitepaper',
+                  to: '/whitepaper/abstract'
+                }
+              ]
+            },
+            {
+              title: 'Community',
+              items: [
+                {
+                  label: 'Discord',
+                  href: 'https://discord.gg/okp4'
+                },
+                {
+                  label: 'Twitter',
+                  href: 'https://twitter.com/OKP4_Protocol'
+                },
+                {
+                  label: 'GitHub',
+                  href: 'https://github.com/okp4'
+                }
+              ]
+            },
+            {
+              title: 'More',
+              items: [
+                {
+                  label: 'Medium',
+                  href: 'https://medium.com/okp4'
+                },
+                {
+                  label: 'OKP4.network',
+                  href: 'https://okp4.network'
+                }
+              ]
+            }
+          ],
+          copyright: `Copyright © ${new Date().getFullYear()} OKP4`
+        },
+        prism: {
+          theme: lightCodeTheme,
+          darkTheme: darkCodeTheme,
+          additionalLanguages: ['prolog']
+        },
+        colorMode: {
+          defaultMode: 'dark'
+        },
+        docs: {
+          sidebar: {
+            hideable: true,
+            autoCollapseCategories: true
+          }
+        }
+      }),
+    plugins: [
+      'docusaurus-plugin-sass',
+      ['drawio', {}],
+      [
+        '@easyops-cn/docusaurus-search-local',
+        {
+          hashed: true,
+          docsRouteBasePath: '/'
+        }
+      ],
+      [
+        '@docusaurus/plugin-content-docs',
+        {
+          id: 'contracts',
+          path: 'contracts',
+          routeBasePath: 'contracts/'
+        }
+      ],
+      [
+        '@docusaurus/plugin-content-docs',
+        {
+          id: 'modules',
+          path: 'modules',
+          routeBasePath: 'modules/'
+        }
+      ],
+      [
+        '@docusaurus/plugin-content-docs',
+        {
+          id: 'commands',
+          path: 'commands',
+          routeBasePath: 'commands/'
+        }
+      ]
     ],
-    [
-      '@docusaurus/plugin-content-docs',
-      {
-        id: 'modules',
-        path: 'modules',
-        routeBasePath: 'modules/'
-      },
-    ],
-    [
-      '@docusaurus/plugin-content-docs',
-      {
-        id: 'commands',
-        path: 'commands',
-        routeBasePath: 'commands/'
-      },
-    ],
-  ],
-  scripts: [
-    "/js/matomo.js",
-    "/js/redirect.js"
-  ]
+    scripts: ['/js/matomo.js', '/js/redirect.js']
+  }
+
+  return config
 }
 
-module.exports = config
+module.exports = createconfig

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@okp4/eslint-config": "^1.1.0",
     "docusaurus-plugin-drawio": "^0.2.0",
     "graphviz-react": "^1.2.5",
+    "remark-kroki": "^0.2.7",
     "markdownlint-cli": "^0.33.0",
     "prettier": "^2.8.3",
     "stylelint": "^14.16.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3638,6 +3638,11 @@ dagre-d3-es@7.0.6:
     d3 "^7.7.0"
     lodash-es "^4.17.21"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
 debug@2.6.9, debug@^2.6.0:
   version "2.6.9"
   resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
@@ -4131,6 +4136,14 @@ feed@^4.2.2:
   dependencies:
     xml-js "^1.6.11"
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 file-entry-cache@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
@@ -4233,6 +4246,13 @@ fork-ts-checker-webpack-plugin@^6.5.0:
     schema-utils "2.7.0"
     semver "^7.3.2"
     tapable "^1.0.0"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -4936,6 +4956,11 @@ is-plain-obj@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz"
 
+is-plain-obj@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
+  integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
+
 is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz"
@@ -5252,6 +5277,11 @@ mark.js@^8.11.1:
   version "8.11.1"
   resolved "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz"
 
+markdown-code-block-meta@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-code-block-meta/-/markdown-code-block-meta-0.0.2.tgz#5dd39bc6ca86c35eccf7003e0990625fabd0daef"
+  integrity sha512-ZHoiTBgMIEP71IN5HJo3eU/7F2A1J4on8LU0bzMe7+n09oANJMKht6/VGHQmA41OK117WZ225f7Imd4IF2bokw==
+
 markdown-escapes@^1.0.0:
   version "1.0.4"
   resolved "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz"
@@ -5424,6 +5454,11 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
 
+mimic-fn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
+
 mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz"
@@ -5525,6 +5560,11 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-emoji@^1.10.0:
   version "1.11.0"
   resolved "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz"
@@ -5536,6 +5576,15 @@ node-fetch@2.6.7:
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.1.tgz#b3eea7b54b3a48020e46f4f88b9c5a7430d20b2e"
+  integrity sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-forge@^1:
   version "1.3.1"
@@ -5701,6 +5750,14 @@ p-map@^4.0.0:
   resolved "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz"
   dependencies:
     aggregate-error "^3.0.0"
+
+p-memoize@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/p-memoize/-/p-memoize-7.1.1.tgz#53b1d0e6007288f7261cfa11a7603b84c9261bfa"
+  integrity sha512-DZ/bONJILHkQ721hSr/E9wMz5Am/OTJ9P6LhLFo2Tu+jL8044tgc9LwHO8g4PiaYePnlVVRAJcKmgy8J9MVFrA==
+  dependencies:
+    mimic-fn "^4.0.0"
+    type-fest "^3.0.0"
 
 p-retry@^4.5.0:
   version "4.6.1"
@@ -6560,6 +6617,17 @@ remark-emoji@^2.2.0:
 remark-footnotes@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-2.0.0.tgz"
+
+remark-kroki@^0.2.7:
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/remark-kroki/-/remark-kroki-0.2.8.tgz#fa551020a1d1e17a6449ebb57966fe40b2bde7b0"
+  integrity sha512-bYwcSSwwpKnlTRC/OKgofdgh2Nk1YG0jfjJg9dyLrwvQMuivG5F1Li+lABaKAcyigWTehvyg6+W4hFfCXBx73Q==
+  dependencies:
+    is-plain-obj "^4.1.0"
+    markdown-code-block-meta "^0.0.2"
+    node-fetch "^3.3.1"
+    p-memoize "^7.1.1"
+    unist-util-visit "^4.1.2"
 
 remark-math@3:
   version "3.0.1"
@@ -7426,6 +7494,11 @@ type-fest@^2.5.0:
   version "2.12.2"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-2.12.2.tgz"
 
+type-fest@^3.0.0:
+  version "3.12.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.12.0.tgz#4ce26edc1ccc59fc171e495887ef391fe1f5280e"
+  integrity sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"
@@ -7523,6 +7596,13 @@ unist-util-is@^4.0.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz"
 
+unist-util-is@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-5.2.1.tgz#b74960e145c18dcb6226bc57933597f5486deae9"
+  integrity sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==
+  dependencies:
+    "@types/unist" "^2.0.0"
+
 unist-util-position@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz"
@@ -7552,6 +7632,14 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
+unist-util-visit-parents@^5.1.1:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-5.1.3.tgz#b4520811b0ca34285633785045df7a8d6776cfeb"
+  integrity sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+
 unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz"
@@ -7559,6 +7647,15 @@ unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.3:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
     unist-util-visit-parents "^3.0.0"
+
+unist-util-visit@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-4.1.2.tgz#125a42d1eb876283715a3cb5cceaa531828c72e2"
+  integrity sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==
+  dependencies:
+    "@types/unist" "^2.0.0"
+    unist-util-is "^5.0.0"
+    unist-util-visit-parents "^5.1.1"
 
 universalify@^2.0.0:
   version "2.0.0"
@@ -7721,6 +7818,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
 web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz"
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## Purpose

This PR adds support for [Kroki!](https://kroki.io/) in the docusaurus markdown. Kroki provides very nice support for several different textual diagrams like [plantUML](https://plantuml.com/fr/), [structurizr](https://github.com/structurizr/dsl) or [BPMN](https://bpmn.io/toolkit/bpmn-js/). This capability is very useful for creating technical diagrams, particularly for editing the technical part of the website.

## Resources
- https://kroki.io/examples.html
- https://github.com/nice-move/remark-kroki