### PR TITLE
ci(workflow): update max old space size to 8192 for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build website
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
+          NODE_OPTIONS: "--max_old_space_size=8192"
         run: |
           yarn build
 


### PR DESCRIPTION
Same than #251 - `publish` workflow was missing.