### PR TITLE
build(project): specify node max_old_space_size in package.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,5 @@ jobs:
           yarn --frozen-lockfile
 
       - name: Build project
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
         run: |
           yarn build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,8 +25,6 @@ jobs:
           yarn --frozen-lockfile
 
       - name: Build website
-        env:
-          NODE_OPTIONS: "--max_old_space_size=8192"
         run: |
           yarn build
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "NODE_OPTIONS='--max_old_space_size=8192' docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",


### PR DESCRIPTION
Self explanatory.

Move the `max_old_space_size` directive from the GitHub workflows to the `package.json` file in order to achieve the same outcome for a local environment.

(related to #252 and #251)