### PR TITLE
fix(tutorial): fix logic module params retrieval

### DIFF
--- a/docs/tutorials/prolog-1.mdx
+++ b/docs/tutorials/prolog-1.mdx
@@ -401,19 +401,24 @@ height: "2637781"
 
 ## Built-in Prolog predicates within the OKP4 blockchain
 
-The logic module interpreter can manage [ichiban/prolo built-in predicates](https://github.com/ichiban/prolog/wiki#predicates) and custom predicates. But their availability is conditioned to the interpreter configuration. For instance, the `halt/1` built-in predicate is not registered in the interpreter; its usage can stop a node.
-To get the list of available predicates, you can query the logic module parameters:
+The logic module interpreter can handle [ichiban/prolog built-in predicates](https://github.com/ichiban/prolog/wiki#predicates) and custom predicates.
+However, their availability depends on the interpreter's configuration. For example, the built-in predicate `halt/1` is not registered in the interpreter, as its use is harmful, as it stops the node executing it.
+
+You can get the list of all available predicates as a set of whitelist / blacklist predicates by querying the logic module parameters.
+
+:::tip
+The whitelist specifies the list of predicates that 
+are allowed, and if not specified, all supported predicates are available. The blacklist specifies the list of predicates that are excluded from the set of allowed precicates. If a predicate
+is included in both whitelist and blacklist, it will be excluded. This means that blacklisted predicates prevails over whitelisted ones.
+:::
+
+To get the list of all available predicates, you can query the logic module parameters:
 
 ```bash
 okp4d --node "https://api.testnet.okp4.network:443/rpc" \
-    query params subspace \
-    logic Interpreter -ojson \
-    | jq -r '.value | fromjson.registered_predicates[]'
+  query logic params -ojson \
+  | jq -r '.params.interpreter.predicates_filter | "whitelist: " + (.whitelist | join(", ")) + "\nblacklist: " + (.blacklist | join(", "))'
 ```
-
-:::caution
-It's worth noticing that, in the next version the logic module parameters won't be stored in the `params` module anymore, but directly in the logic module itself, so the query to retrieve them will change. And the configuration will be based on white & black lists of predicates
-:::
 
 Several [predicates have been specially created in the logic module](https://github.com/okp4/okp4d/tree/main/x/logic/predicate) to enable rules with the blockchain state or operate crypto utilities.
 


### PR DESCRIPTION
Revise the tutorial documentation to reflect changes in how the parameters of the Logic module are retrieved, following the chain's upgrade.