### PR TITLE
ci(workflow): exclude generated documentation from linter

### DIFF
--- a/.github/workflows/auto-fix-md.yml
+++ b/.github/workflows/auto-fix-md.yml
@@ -20,6 +20,7 @@ jobs:
         continue-on-error: true
         with:
           args: "**/*.md"
+          ignore: contracts/**/*.md contracts_versioned_docs/**/*.md modules/**/*.md modules_versioned_docs/**/*.md commands/**/*.md commands_versioned_docs/**/*.md
           fix: true
 
       - name: Commit changes


### PR DESCRIPTION
Fixes #286.