### PR TITLE
style: improve style mermaid diagrams light/dark mode

### DIFF
--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -42,6 +42,10 @@
   --ifm-navbar-item-color: linear-gradient(39.81deg, #006796 21.82%, #00b6b7 98.43%);
   --ifm-article-anchor-color: #ff9500;
   --ifm-graph-svg-background-color: #ecf0f1;
+  --ifm-graph-base-actor-color: #fb6700;
+  --ifm-graph-base-line-color: #966a13;
+  --ifm-graph-base-rect-color: #13264d;
+  --ifm-graph-base-rect-text-color: white;
   --ifm-knowledge-graph-data-fill-color: #f3a83f;
   --ifm-knowledge-graph-service-fill-color: #bf0000;
   --ifm-knowledge-graph-base-stroke-color: #433d32;
@@ -61,6 +65,10 @@
   --ifm-footer-background-color-main: transparent linear-gradient(180deg, #102040 0%, #061126 100%)
     0% 0% no-repeat padding-box;
   --ifm-navbar-background-color: #0f1e3d;
+  --ifm-graph-base-actor-color: #1f4799;
+  --ifm-graph-base-line-color: #4d6699;
+  --ifm-graph-base-rect-color: #d8d0c6;
+  --ifm-graph-base-rect-text-color: #0f224a;
   --search-local-highlight-color: #877b65;
   --ifm-knowledge-graph-base-stroke-color: white;
   --ifm-navbar-search-input-background-color: rgb(255 255 255 / 4%);

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -216,6 +216,42 @@ svg {
   }
 }
 
+.mermaid {
+  svg {
+    path.messageLine0 {
+      stroke: var(--ifm-graph-base-line-color) !important;
+    }
+
+    line {
+      fill: var(--ifm-graph-base-line-color) !important;
+      stroke: var(--ifm-graph-base-line-color) !important;
+    }
+  }
+
+  .loopText > tspan,
+  text.actor > tspan,
+  .messageText {
+    fill: var(--ifm-menu-color) !important;
+  }
+
+  g {
+    .actor,
+    circle {
+      fill: var(--ifm-graph-base-actor-color) !important;
+      stroke: var(--ifm-graph-base-actor-color) !important;
+    }
+
+    .note {
+      fill: var(--ifm-graph-base-rect-color) !important;
+      stroke: var(--ifm-graph-base-rect-color) !important;
+    }
+
+    .noteText > tspan {
+      fill: var(--ifm-graph-base-rect-text-color) !important;
+    }
+  }
+}
+
 .docs-doc-id-faq\/faq {
   .markdown > h2 {
     font-size: var(--ifm-h3-font-size);


### PR DESCRIPTION
This PR enhance the syle for `mermaid diagrams` for dark and light mode by rendering the colors defined by `OKP4/UI`.
<details>

![Screenshot 2023-08-25 at 14 14 51](https://github.com/okp4/docs/assets/93918596/447a3856-c622-4b1d-8b4b-3c8fe7c63260)

![Screenshot 2023-08-25 at 14 15 07](https://github.com/okp4/docs/assets/93918596/0b5cca55-be65-4c2e-8447-71995ea7e511)

<summary> Screenshots </summary>

