### PR TITLE
Added instruction to fix "bash: okp4d not found" issue

### DIFF
--- a/docs/tutorials/cli-1.mdx
+++ b/docs/tutorials/cli-1.mdx
@@ -58,7 +58,13 @@ make build
 make install`}
 </CodeBlock>
 
-3. Verify the installation:
+3. Move the executable binary in a folder set in `$PATH` (`/usr/local/bin` for example)
+
+```bash
+mv ./target/dist/okp4d /usr/local/bin
+```
+
+4. Verify the installation:
 
 ```bash
 okp4d version

--- a/docs/tutorials/cli-1.mdx
+++ b/docs/tutorials/cli-1.mdx
@@ -50,19 +50,18 @@ Certain aspects, such as your computer's unique characteristics (particularly fo
 git clone https://github.com/okp4/okp4d.git && cd okp4d
 ```
 
-2. Build and install:
+2. Make sure `$GOPATH/bin` is set on the $PATH environment variable. You can add it like this:
+
+```bash
+export PATH=${PATH}:`go env GOPATH`/bin
+```
+
+3. Build and install:
 
 <CodeBlock language="bash">
   {`git checkout ${data.okp4dVersion}
-make build
 make install`}
 </CodeBlock>
-
-3. Move the executable binary in a folder set in `$PATH` (`/usr/local/bin` for example)
-
-```bash
-mv ./target/dist/okp4d /usr/local/bin
-```
 
 4. Verify the installation:
 


### PR DESCRIPTION
Tutorial about the CLI: add the command to move the `okp4d` binary to a folder declared in $PATH