### PR TITLE
🪚 Refactor: move API menu

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -99,31 +99,6 @@ async function createconfig() {
               activeBasePath: '/tutorials'
             },
             {
-              type: 'dropdown',
-              label: 'API',
-              position: 'left',
-              items: [
-                {
-                  type: 'doc',
-                  label: 'Contracts',
-                  docId: 'README',
-                  docsPluginId: 'contracts'
-                },
-                {
-                  type: 'doc',
-                  label: 'Modules',
-                  docId: 'logic',
-                  docsPluginId: 'modules'
-                },
-                {
-                  type: 'doc',
-                  label: 'Commands',
-                  docId: 'okp4d',
-                  docsPluginId: 'commands'
-                }
-              ]
-            },
-            {
               to: '/faq',
               position: 'left',
               label: 'FAQ',

--- a/sidebars.js
+++ b/sidebars.js
@@ -56,7 +56,22 @@ const sidebars = {
               dirName: 'technical-documentation/ontology'
             }
           ]
-        }
+        },
+        {
+          type: 'link',
+          label: "Smart contracts",
+          href: '/contracts',
+        },
+        {
+          type: 'link',
+          label: "Modules",
+          href: '/modules/logic',
+        },
+        {
+          type: 'link',
+          label: "Commands line interface",
+          href: '/commands/okp4d',
+        },
       ]
     }
   ],


### PR DESCRIPTION
Move the api menu from the main navigation bar to the technical documentation sidebar.

We cannot reference by `docId` on the sidebar item since it's relative to the `docs` folder, while `contracts`, `modules` or `commands` are `docId` at the root path. So I put a [`link` menu type](https://docusaurus.io/docs/2.2.0/sidebar/items#sidebar-item-link). The only side effect of this is that if we change the path of one of the doc module, we need to change it on the sidebar too. But don't worry, when docusaurus build app, it will check all invalid links. 
