### PR TITLE
ci(workflow): add lint-web job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -151,6 +151,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 16.18
+          cache: yarn
 
       - name: Fetch dependencies
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -94,6 +94,56 @@ jobs:
         env:
           FOLDER: ./static
 
+  lint-web:
+    runs-on: ubuntu-22.04
+    env:
+      WEB_PORT: 3000
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup node environment (for building)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16.18
+          cache: yarn
+
+      - name: Fetch dependencies
+        run: |
+          yarn --frozen-lockfile
+
+      - name: Start web server
+        run: |
+          yarn build
+          yarn serve --port $WEB_PORT --no-open &
+          sleep 2
+
+      - name: Create artifacts directory
+        run: |
+          mkdir -p ${{ github.workspace }}/tmp/artifacts
+
+      - name: Run Lighthouse
+        uses: foo-software/lighthouse-check-action@v10.0.0
+        with:
+          prCommentEnabled: true
+          maxRetries: 2
+          outputDirectory: ${{ github.workspace }}/tmp/artifacts
+          device: all
+          urls: >-
+            http://localhost:${{ env.WEB_PORT }}/
+          gitHubAccessToken: ${{ secrets.OKP4_TOKEN }}
+
+      - name: Upload lighthouse reports
+        uses: actions/upload-artifact@v3.1.3
+        with:
+          name: Lighthouse reports
+          path: ${{ github.workspace }}/tmp/artifacts
+
+      - name: Stop web server
+        if: always()
+        run: |
+          kill $(lsof -t -i:$WEB_PORT)
+
   report-new-dependencies:
     runs-on: ubuntu-22.04
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 16.18
+          cache: yarn
 
       - name: Fetch dependencies
         run: |

--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -63,6 +63,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 16.18
+          cache: yarn
 
       - name: Bump new version
         if: ${{ github.event.inputs.draft == 'false' }}


### PR DESCRIPTION
Self explanatory (similar to [okp4/dataverse-portal](https://github.com/okp4/dataverse-portal/blob/64fbd7c69d32ba29e24f1bfce14d77282af4bfd8/.github/workflows/lint.yml#L120)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new job "lint-web" for performance testing.
- **Chores**
	- Implemented caching for yarn in various workflows to improve build process efficiency.
- **Refactor**
	- Modified the "report-new-dependencies" job to include a cache setting for Node version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->