### PR TITLE
feat: add GPT link in top bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -105,6 +105,11 @@ async function createconfig() {
               activeBasePath: '/faq'
             },
             {
+              href: 'https://chat.openai.com/g/g-zUzcYmVbX-okp4-druid-oracle-beta',
+              position: 'left',
+              label: 'OKP4 GPT',
+            },
+            {
               type: 'docsVersionDropdown',
               position: 'right',
               dropdownItemsAfter: [{ to: '/contracts/', label: 'Latest version' }],

--- a/sidebars.js
+++ b/sidebars.js
@@ -98,6 +98,13 @@ const sidebars = {
       id: 'faq/faq',
       label: 'FAQ'
     }
+  ],
+  gpt: [
+    {
+      type: 'link',
+      href: 'https://chat.openai.com/g/g-zUzcYmVbX-okp4-druid-oracle-beta',
+      label: 'OKP4 GPT'
+    }
   ]
 }
 


### PR DESCRIPTION
This PR aims at adding an external link to the top bar towards the OKP4 GPT. 

Do you agree to name it "OKP4 GPT" or should we put "Oracle Druid" 


<img width="1413" alt="Capture d’écran 2023-12-18 à 09 50 51" src="https://github.com/okp4/docs/assets/92780073/5083f1f4-6365-4c61-ba56-db0bde94ffc9">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new navigation link to the chat page for OKP4 GPT.
- **Documentation**
  - Added a new sidebar entry for "OKP4 GPT" with a direct link to the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->