### PR TITLE
fix(docs): remove trailing / in URL links (index page)

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -13,7 +13,7 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
   <div class="row row-cols-1 row-cols-md-2a g-3">
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
-        <a href="/whitepaper/abstract/" class="card-title card-link stretched-link">
+        <a href="/whitepaper/abstract" class="card-title card-link stretched-link">
           <h2>Whitepaper</h2>
         </a>
         <p class="card-text">What is OKP4? What is it for? What is the technical architecture?</p>
@@ -64,7 +64,7 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
   <div class="row row-cols-1 row-cols-md-3a g-3">
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
-        <a href="/whitepaper/abstract/" class="card-title card-link stretched-link">
+        <a href="/whitepaper/abstract" class="card-title card-link stretched-link">
           <h2>Learn OKP4 in 5'</h2>
         </a>
         <p class="card-text">Discover OKP4 and all of its features.</p>
@@ -72,7 +72,7 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
     </div>
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
-        <a href="/whitepaper/solution/" class="card-title card-link stretched-link">
+        <a href="/whitepaper/solution" class="card-title card-link stretched-link">
           <h2>OKP4 Solution</h2>
         </a>
         <p class="card-text">
@@ -87,7 +87,7 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
   <div class="row row-cols-1 row-cols-md-3a g-3">
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
-        <a href="/whitepaper/architecture/" class="card-title card-link stretched-link">
+        <a href="/whitepaper/architecture" class="card-title card-link stretched-link">
           <h2>Architecture</h2>
         </a>
         <p class="card-text">Everything about the OKP4 Architecture</p>
@@ -95,7 +95,7 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
     </div>
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
-        <a href="/whitepaper/token-model/" class="card-title card-link stretched-link">
+        <a href="/whitepaper/token-model" class="card-title card-link stretched-link">
           <h2>Tokens</h2>
         </a>
         <p class="card-text">Everything about the KNOW token and its ecosystem</p>
@@ -151,7 +151,7 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
     </div>
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
-        <a href="https://github.com/okp4/" class="card-title card-link stretched-link">
+        <a href="https://github.com/okp4" class="card-title card-link stretched-link">
           <h2>GitHub</h2>
         </a>
         <p class="card-text">Contribute to the OKP4 protocol and gateways.</p>
@@ -163,7 +163,7 @@ Welcome! OKP4 is a public PoS layer 1 blockchain built for trust-minimized data 
   <div class="row row-cols-1 row-cols-md-2a g-4">
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
-        <a href="https://blog.okp4.network/" class="card-title card-link stretched-link">
+        <a href="https://blog.okp4.network" class="card-title card-link stretched-link">
           <h2>Blog</h2>
         </a>
         <p class="card-text">Know more about our vision.</p>
@@ -192,7 +192,7 @@ import IconOKP4 from '/img/socials/logo-okp4-round.svg'
 
 <div className="social_media">
 <a
-  href="https://okp4.network/"
+  href="https://okp4.network"
   target="_blank"
   rel="noreferrer"
   className="socials_link website"
@@ -215,7 +215,7 @@ import IconOKP4 from '/img/socials/logo-okp4-round.svg'
 </a>
 
 <a
-  href="https://www.linkedin.com/company/okp4-open-knowledge-protocol-for/mycompany/"
+  href="https://www.linkedin.com/company/okp4-open-knowledge-protocol-for/mycompany"
   target="_blank"
   rel="noreferrer"
   className="socials_link linkedin"
@@ -224,7 +224,7 @@ import IconOKP4 from '/img/socials/logo-okp4-round.svg'
 </a>
 
 <a
-  href="https://blog.okp4.network/"
+  href="https://blog.okp4.network"
   target="_blank"
   rel="noreferrer"
   className="socials_link medium"


### PR DESCRIPTION
Self explanatory. The trailing`/` in the URLs of internal links was causing a '404 Not Found' page to briefly appear before being redirected to the correct address without the slash. This issue was particularly noticeable on slow network connections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated navigation and social media links to ensure they align with the target URLs by removing trailing slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->