### PR TITLE
ci(workflow): fix fetch-depth for publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup node environment (for building)
         uses: actions/setup-node@v4


### PR DESCRIPTION
This PR follows https://github.com/okp4/docs/pull/387 and addresses the issue of the Last updated on-time / author always same for every page as per @JulienMassonnat's [comment](https://github.com/okp4/docs/pull/387#issuecomment-1892793812). It modifies the git fetch depth in the CI action for publishing (only), as detailed in this discussion: https://github.com/facebook/docusaurus/issues/2798#issuecomment-636602951.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the repository checkout process to ensure full history is available during workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->