### PR TITLE
feat(academy): install a quiz for part "rules"

### DIFF
--- a/docs/academy/rules-quiz.json
+++ b/docs/academy/rules-quiz.json
@@ -1,6 +1,6 @@
 {
   "quizTitle": "Test your knowledge!",
-  "nrOfQuestions": "1",
+  "nrOfQuestions": "4",
   "questions": [
     {
       "question": "Which of the following best describes the role of Prolog in the OKP4 protocol?",
@@ -13,6 +13,51 @@
         "Prolog functions as a cryptocurrency wallet in the OKP4 protocol, managing digital assets and facilitating transactions between users."
       ],
       "correctAnswer": "3",
+      "messageForCorrectAnswer": "Correct answer. Good job.",
+      "messageForIncorrectAnswer": "Incorrect answer. Please try again.",
+      "point": "1"
+    },
+    {
+      "question": "How does the OKP4 protocol handle the dynamic nature of resource management?",
+      "questionType": "text",
+      "answerSelectionType": "single",
+      "answers": [
+        "By enforcing static rules.",
+        "Through Dynamic Rule Updates in real-time.",
+        "By allowing only manual updates to rules.",
+        "By relying on a centralized system for adaptation."
+      ],
+      "correctAnswer": "2",
+      "messageForCorrectAnswer": "Correct answer. Good job.",
+      "messageForIncorrectAnswer": "Incorrect answer. Please try again.",
+      "point": "1"
+    },
+    {
+      "question": "What is the role of hierarchy of norms in OKP4 resource consents?",
+      "questionType": "text",
+      "answerSelectionType": "single",
+      "answers": [
+        "It establishes the order of precedence among different norms.",
+        "It increases transparency.",
+        "It eliminates conflicts.",
+        "It enforces static rules."
+      ],
+      "correctAnswer": "1",
+      "messageForCorrectAnswer": "Correct answer. Good job.",
+      "messageForIncorrectAnswer": "Incorrect answer. Please try again.",
+      "point": "1"
+    },
+    {
+      "question": "In Prolog, what is the declarative style?",
+      "questionType": "text",
+      "answerSelectionType": "single",
+      "answers": [
+        "Specifying how to achieve a task",
+        "Describing relationships and rules without step-by-step instructions.",
+        "Focusing on sequential programming.",
+        "Ignoring logical inferenceIt establishes the order of precedence among different norms."
+      ],
+      "correctAnswer": "2",
       "messageForCorrectAnswer": "Correct answer. Good job.",
       "messageForIncorrectAnswer": "Incorrect answer. Please try again.",
       "point": "1"

--- a/docs/academy/rules-quiz.json
+++ b/docs/academy/rules-quiz.json
@@ -1,0 +1,21 @@
+{
+  "quizTitle": "Test your knowledge!",
+  "nrOfQuestions": "1",
+  "questions": [
+    {
+      "question": "Which of the following best describes the role of Prolog in the OKP4 protocol?",
+      "questionType": "text",
+      "answerSelectionType": "single",
+      "answers": [
+        "Prolog is primarily used for front-end development within the OKP4 ecosystem, focusing on user interface design and experience.",
+        "Prolog serves as a database management system in OKP4, handling the storage, retrieval, and update of data within the protocol.",
+        "Prolog is employed as an on-chain module within OKP4, interpreting rules related to governance and consent, and ensuring secure and reliable decentralized decision-making.",
+        "Prolog functions as a cryptocurrency wallet in the OKP4 protocol, managing digital assets and facilitating transactions between users."
+      ],
+      "correctAnswer": "3",
+      "messageForCorrectAnswer": "Correct answer. Good job.",
+      "messageForIncorrectAnswer": "Incorrect answer. Please try again.",
+      "point": "1"
+    }
+  ]
+}

--- a/docs/academy/rules.mdx
+++ b/docs/academy/rules.mdx
@@ -2,6 +2,9 @@
 sidebar_class_name: hidden
 ---
 
+import Quiz from 'react-quiz-component';
+import * as quiz from './rules-quiz.json';
+
 # Define any rule
 
 <i>Reading time: {readingTime} min</i>
@@ -242,3 +245,5 @@ Example queries demonstrate how Prolog can be used to check if a user has access
 Note: The OKP4 SDK contains templates of governance rules that you can use and adapt to your needs.
 
 As we delve deeper into the OKP4 Academy, understanding the intricacies of resource rules becomes paramount. These rules serve as the backbone of the protocol, ensuring that off-chain resources are governed with precision, flexibility, and transparency. Join us as we unravel the complexities of resource rule management within the dynamic landscape of OKP4.
+
+<Quiz quiz={quiz}/>

--- a/src/scss/custom.scss
+++ b/src/scss/custom.scss
@@ -2,6 +2,7 @@
 @import "main";
 @import "animation";
 @import "card";
+@import "quiz";
 
 @font-face {
   font-family: "Barlow bold";

--- a/src/scss/quiz.scss
+++ b/src/scss/quiz.scss
@@ -1,0 +1,33 @@
+div.react-quiz-container {
+  border: 1px solid var(--ifm-toc-border-color);
+  border-color: var(--ifm-color-primary);
+  padding: 20px;
+  background-color: var(--ifm-navbar-background-color);
+  max-width: 100%;
+
+  .questionWrapper {
+    .answerBtn {
+      font-weight: var(--ifm-font-weight-semibold, 600);
+      font-family: var(--ifm-font-family-base, sans-serif);
+
+      &:hover,
+      &:focus {
+        border-color: var(--ifm-color-primary);
+      }
+    }
+
+    .btn {
+      &.incorrect {
+        background: var(--ifm-color-danger);
+      }
+
+      &.correct {
+        background: var(--ifm-color-success);
+      }
+    }
+  }
+
+  .quiz-result-filter div.filter-dropdown-select {
+    height: auto;
+  }
+}


### PR DESCRIPTION
Add a quiz section into the "rules" part of the academy, providing an opportunity for readers to assess of their understanding of the content.

<img width="1383" alt="image" src="https://github.com/okp4/docs/assets/9574336/1a93987f-5e2e-4cb3-9803-fa6b7637d3ed">

---

PS: I have refined the CSS to improve the visual appeal of the quiz; however, this is merely a preliminary version. Further aesthetic improvements to be planned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Integrated a quiz component into the academy section.
	- Enhanced user interface with new styles for the quiz feature.

- **Documentation**
	- Updated documentation to include the new quiz component.

- **Style**
	- Added custom styling for the quiz, including layout and interactive elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->