### PR TITLE
feat(technical): make ontology generated documentation visible

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -174,6 +174,13 @@ const config = {
           {
             type: 'docsVersionDropdown',
             position: 'right',
+            dropdownItemsAfter: [{ to: '/ontology/schemas', label: 'Latest version' }],
+            docsPluginId: 'ontology',
+            dropdownActiveClassDisabled: true
+          },
+          {
+            type: 'docsVersionDropdown',
+            position: 'right',
             dropdownItemsAfter: [{ to: '/predicates/predicates', label: 'Latest version' }],
             docsPluginId: 'predicates',
             dropdownActiveClassDisabled: true
@@ -329,6 +336,14 @@ const config = {
         id: 'contracts',
         path: 'contracts',
         routeBasePath: 'contracts/'
+      }
+    ],
+    [
+      '@docusaurus/plugin-content-docs',
+      {
+        id: 'ontology',
+        path: 'ontology',
+        routeBasePath: 'ontology/'
       }
     ],
     [

--- a/sidebars.js
+++ b/sidebars.js
@@ -35,7 +35,7 @@ const sidebars = {
       items: [
         {
           type: 'doc',
-          id: 'technical-documentation/overview',
+          id: 'technical-documentation/overview'
         },
         {
           type: 'category',
@@ -59,24 +59,33 @@ const sidebars = {
         },
         {
           type: 'link',
-          label: "Smart contracts",
-          href: '/contracts',
+          label: 'Smart contracts',
+          href: '/contracts'
+        },
+        {
+          type: 'html',
+          value: '<hr/>'
+        },
+        {
+          type: 'link',
+          label: 'Ontology',
+          href: '/ontology/schemas'
         },
         {
           type: 'link',
           label: 'Governance Predicates',
-          href: '/predicates/predicates',
+          href: '/predicates/predicates'
         },
         {
           type: 'link',
-          label: "Modules",
-          href: '/modules/logic',
+          label: 'Modules',
+          href: '/modules/logic'
         },
         {
           type: 'link',
-          label: "Commands line interface",
-          href: '/commands/okp4d',
-        },
+          label: 'Commands line interface',
+          href: '/commands/okp4d'
+        }
       ]
     }
   ],
@@ -98,7 +107,7 @@ const sidebars = {
       id: 'faq/faq',
       label: 'FAQ'
     }
-  ],
+  ]
 }
 
 module.exports = sidebars


### PR DESCRIPTION
After the changes in https://github.com/okp4/ontology/pull/229, set up Docusaurus to include the ontology's generated documentation in the "Technical Documentation" section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an 'Ontology' section with a dedicated navigation path and version dropdown, enhancing the documentation structure.
- **Documentation**
	- Updated technical documentation overview and improved navigation with revised labels and links for key topics such as "Smart Contracts," "Governance Predicates," "Modules," and "Command Line Interface."
	- Enhanced readability and organization of sidebar navigation with visual separators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->