### PR TITLE
build(project): add json and sparql prism languages

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -308,7 +308,7 @@ const config = {
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
-        additionalLanguages: ['prolog', 'turtle', 'bash']
+        additionalLanguages: ['prolog', 'turtle', 'bash', 'json', 'sparql']
       },
       colorMode: {
         defaultMode: 'dark'


### PR DESCRIPTION
Add support for `json` and `sparql` languages for syntax highlighting.

_Before:_

![image](https://github.com/okp4/docs/assets/9574336/64bf0d5c-56c3-458b-8de3-a704fec457f0)

_After:_

![image](https://github.com/okp4/docs/assets/9574336/4ec68b14-7c4c-4624-ab46-ecfc1e9342dd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded syntax highlighting support to include "json" and "sparql" languages in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->