### PR TITLE
build(project): fix broken link on contracts v4.0.0

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -173,7 +173,7 @@ const config = {
           {
             type: 'docsVersionDropdown',
             position: 'right',
-            dropdownItemsAfter: [{ to: '/contracts/', label: 'Latest version' }],
+            dropdownItemsAfter: [{ to: '/contracts/okp4-cognitarium', label: 'Latest version' }],
             docsPluginId: 'contracts',
             dropdownActiveClassDisabled: true
           },

--- a/sidebars.js
+++ b/sidebars.js
@@ -96,7 +96,7 @@ const sidebars = {
         {
           type: 'link',
           label: 'Smart contracts',
-          href: '/contracts'
+          href: '/contracts/okp4-cognitarium'
         },
         {
             type: 'link',


### PR DESCRIPTION
This PR addresses the issue of a broken link in the technical documentation of [contracts v4.0.0](https://github.com/okp4/contracts/releases/tag/v4.0.0). This issue prevents the deployment of any new updates to the docusaurus site.

The problem lies with the file `README.md` that has been removed in the PR https://github.com/okp4/contracts/pull/311,  part of this release. This file served as the default page for the technical documentation of contracts. To fix this, we simply designate `okp4-cognitarium` as the target (the same way we already do for ontology, modules, etc.)