### PR TITLE
fix: force light mode

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -320,7 +320,8 @@ const config = {
       },
       colorMode: {
         defaultMode: 'light',
-        disableSwitch: true
+        disableSwitch: true,
+        respectPrefersColorScheme: false
       },
       docs: {
         sidebar: {


### PR DESCRIPTION
This PR aims to force the light mode even if the preferred mode of the navigator or the cookies are set up on dark mode. 