### PR TITLE
Ci/documentation pr token

### DIFF
--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -100,10 +100,11 @@ jobs:
           title: 📜 Add ${{ github.event.inputs.version }} ${{ github.event.inputs.section }} documentation version
           body: |
             #### 📜 Documentation update
-            
+
             🎉 A new version of [${{ github.event.inputs.repository }}](https://github.com/${{ github.event.inputs.repository }}/releases/tag/${{ github.event.inputs.version }}) is available.
-            
-            This PR add this new `${{ github.event.inputs.version }}`` version into the documentation.
+
+            This PR add this new `${{ github.event.inputs.version }}` version into the documentation.
+          labels: documentation
           assignees: ccamel,amimart
           reviewers: ccamel,amimart
           add-paths: |

--- a/.github/workflows/update-versioned-docs.yml
+++ b/.github/workflows/update-versioned-docs.yml
@@ -92,6 +92,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         if: ${{ github.event.inputs.draft == 'false' && steps.changed-files.outputs.any_changed }}
         with:
+          token: ${{ secrets.OKP4_TOKEN }}
           commit-message: "feat(${{ github.event.inputs.section }}): add ${{ github.event.inputs.repository }} ${{ github.event.inputs.version }} ${{ github.event.inputs.section }} documentation"
           committer: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }} <${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}>
           author: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }} <${{ secrets.OKP4_BOT_GIT_AUTHOR_EMAIL }}>
@@ -99,8 +100,10 @@ jobs:
           title: 📜 Add ${{ github.event.inputs.version }} ${{ github.event.inputs.section }} documentation version
           body: |
             #### 📜 Documentation update
+            
             🎉 A new version of [${{ github.event.inputs.repository }}](https://github.com/${{ github.event.inputs.repository }}/releases/tag/${{ github.event.inputs.version }}) is available.
-            This PR add this new ${{ github.event.inputs.version }} version into the documentation.
+            
+            This PR add this new `${{ github.event.inputs.version }}`` version into the documentation.
           assignees: ccamel,amimart
           reviewers: ccamel,amimart
           add-paths: |


### PR DESCRIPTION
This PR introduces the specification of the token to be used when creating PRs for updating documentation following a release. Initially, the [github-actions](https://github.com/apps/github-actions) bot was employed for this task. Now, the @bot-anik bot will be used instead. This change should also address the issue with workflows related to this PR that appeared to never run.

Additionally, the PR has been assigned the `documentation` label.

<img width="931" alt="image" src="https://github.com/okp4/docs/assets/9574336/e143bc8e-fbc2-4bfb-86a6-f2e8af21cc92">



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Improved clarity in pull request bodies by formatting version numbers with backticks.
	- Introduced a new label for documentation-related changes.
	- Concealed internal code changes for confidentiality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->