### PR TITLE
Ci/dependabot docusaurus group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      docusaurus:
+        patterns:
+          - '@docusaurus/*'
     reviewers:
       - ccamel
     assignees:


### PR DESCRIPTION
Ok so yeah time to act, and group `@docusaurus/*` updates.
Future me, you’re welcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management settings by removing a user from reviewer and assignee lists.
  * Added a new group for Docusaurus-related dependencies to improve organization of updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->