### PR TITLE
Build/docusaurus config v3 v4

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -109,6 +109,8 @@ const config = {
     v4: {
       removeLegacyPostBuildHeadAttribute: true,
       useCssCascadeLayers: true,
+      siteStorageNamespacing: true,
+      mdx1CompatDisabledByDefault: true,
       fasterByDefault: true
     }
   },

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     ]
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.8.1",
-    "@docusaurus/types": "^3.8.1",
+    "@docusaurus/module-type-aliases": "^3.10.1",
+    "@docusaurus/types": "^3.10.1",
     "@nivo/line": "^0.99.0",
     "docusaurus-plugin-drawio": "^0.4.0",
     "graphviz-react": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1841,7 +1841,7 @@
     vfile "^6.0.1"
     webpack "^5.88.1"
 
-"@docusaurus/module-type-aliases@3.10.1", "@docusaurus/module-type-aliases@^3.8.1":
+"@docusaurus/module-type-aliases@3.10.1", "@docusaurus/module-type-aliases@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz#22d39177c296786eb6e0d940699cd590cc93ca77"
   integrity sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==
@@ -2138,7 +2138,7 @@
     fs-extra "^11.1.1"
     tslib "^2.6.0"
 
-"@docusaurus/types@3.10.1", "@docusaurus/types@^3.8.1":
+"@docusaurus/types@3.10.1", "@docusaurus/types@^3.10.1":
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-3.10.1.tgz#d42837938ae43ca2be0ca47e63e00476b5eb94be"
   integrity sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==


### PR DESCRIPTION
Prepare [Docusaurus](https://docusaurus.io/) config for [future v4](https://docusaurus.io/blog/releases/3.10) + fix dependencies alignment with `3.10.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docusaurus dependencies to version 3.10.1 for improved stability and compatibility.
  * Enabled storage namespacing and updated MDX compatibility settings in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->