### PR TITLE
fix(predicate): point to the predicate docs introduction

### DIFF
--- a/docs/technical-reference/technical-reference.mdx
+++ b/docs/technical-reference/technical-reference.mdx
@@ -73,7 +73,7 @@ Predicate references cover the predicates used to express governance rules and r
   <div class="row row-cols-1 row-cols-md-2a g-3">
     <div class="col">
       <div class="card card-body h-100 d-flex flex-column">
-        <a href="/predicates/apply/foldl_4" class="card-title card-link stretched-link">
+        <a href="/predicates/next" class="card-title card-link stretched-link">
           <h2>Prolog Predicates</h2>
         </a>
         <p class="card-text">Reference for predicates used to express governance rules and query protocol-relevant facts.</p>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -184,7 +184,7 @@ const config = {
           {
             type: 'docsVersionDropdown',
             position: 'right',
-            dropdownItemsAfter: [{ to: '/predicates/apply/foldl_4', label: 'Latest version' }],
+            dropdownItemsAfter: [{ to: '/predicates/next', label: 'Latest version' }],
             docsPluginId: 'predicates',
             dropdownActiveClassDisabled: true
           },
@@ -344,7 +344,7 @@ const config = {
       {
         id: 'predicates',
         path: 'predicates',
-        routeBasePath: 'predicates/'
+        routeBasePath: 'predicates'
       }
     ],
     [


### PR DESCRIPTION
Closes #605 (minimal).

See https://github.com/axone-protocol/axoned/pull/1162.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated predicates documentation and navigation links to direct to the general predicates section instead of a specific example page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->