### PR TITLE
fix(style): correct mobile navbar responsiveness

### DIFF
--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -59,9 +59,7 @@ html {
     flex-direction: row-reverse;
 
     @media (width <= 996px) {
-      position: absolute;
-      right: 55px;
-      top: 40px;
+      display: none;
     }
   }
 
@@ -107,7 +105,10 @@ html {
     height: 72px;
     border-bottom: 1px solid var(--axone-border-muted);
     background: rgb(25 23 22 / 92%);
-    backdrop-filter: blur(12px);
+
+    @media (width > 996px) {
+      backdrop-filter: blur(12px);
+    }
   }
 
   .navbar__items {
@@ -120,6 +121,11 @@ html {
 
       .navbar__brand {
         width: 100%;
+      }
+
+      .navbar__item,
+      .navbar__link:not(.navbar__brand) {
+        display: none;
       }
     }
 
@@ -184,7 +190,7 @@ html {
       flex: 0 0 100%;
       max-width: 100%;
 
-      @media (width >= 320px) {
+      @media (width >= 480px) {
         flex: 0 0 50%;
         max-width: 50%;
       }


### PR DESCRIPTION
Fix mobile responsiveness issues in the Docusaurus navbar:
- Prevent the mobile drawer from being constrained by the navbar height
- Hide desktop navbar items on mobile to avoid overlap
- Adjust footer columns to prevent horizontal overflow on small screens

<img width="390" height="4620" alt="image" src="https://github.com/user-attachments/assets/3317ab17-262e-45e5-8813-7e7b7467677d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced navigation bar responsiveness for mobile and tablet devices with optimized visibility controls
  * Refined visual effects and layout adjustments across different screen sizes
  * Optimized footer column layout for improved viewing experience at all breakpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->