### PR TITLE
build(deps): bump node from 20 to 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node environment (for building)
         uses: actions/setup-node@v6
         with:
-          node-version: '20.20'
+          node-version: '22'
 
       - name: Fetch dependencies
         run: |

--- a/.github/workflows/capture-website.yml
+++ b/.github/workflows/capture-website.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup node environment
         uses: actions/setup-node@v6
         with:
-          node-version: '20.20'
+          node-version: '22'
           # don't use cache as it may interfere with other jobs
           # cache: npm
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Setup node environment (for building)
         uses: actions/setup-node@v6
         with:
-          node-version: '20.20'
+          node-version: '22'
           cache: yarn
 
       - name: Fetch dependencies
@@ -200,7 +200,7 @@ jobs:
       - name: Setup node environment (for building)
         uses: actions/setup-node@v6
         with:
-          node-version: '20.20'
+          node-version: '22'
           cache: yarn
 
       - name: Fetch dependencies

--- a/.github/workflows/sync-external-docs.yml
+++ b/.github/workflows/sync-external-docs.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup node environment
         uses: actions/setup-node@v6
         with:
-          node-version: "20.20"
+          node-version: "22"
           cache: yarn
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "web": "https://axone.xyz"
   },
   "engines": {
-    "node": "~20.20",
+    "node": ">=22",
     "yarn": "~1.22.17"
   },
   "scripts": {


### PR DESCRIPTION
Self explanatory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project and CI workflows to use Node.js 22.
  * Raised the minimum supported Node.js version to 22 for local development and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->